### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ russian-doll
 Install through  [composer](https://getcomposer.org/) package manager.
 Find it on [packagist](https://packagist.org/packages/g4/russian-doll).
 
-    require: "g4/russian-doll": "*"
-    
+```sh
+composer require g4/russian-doll
+```
 Dependency:
 * [g4/mcache](https://github.com/g4code/mcache) package.
 


### PR DESCRIPTION
Updated installation instructions via composer to use the `composer require` command without specifying a version.
This is the new recommended way of providing this information and it leads to composer picking the proper version constraint (i.e ~1.2), updating the `composer.json` and running install, all in one command.
