### PR TITLE
Fixed bug overwriting data passed to RussianDoll::write() when empty …

### DIFF
--- a/src/G4/RussianDoll/RussianDoll.php
+++ b/src/G4/RussianDoll/RussianDoll.php
@@ -49,6 +49,7 @@ class RussianDoll
 
     public function write($data)
     {
+        $this->getDigestedKey(); // duplicated call here because otherwise it will overwrite $data sent to mcache instance
         $this->mcache
             ->object($data)
             ->id($this->getDigestedKey())


### PR DESCRIPTION
…timePart inside Digestor::getTimePart()